### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -33,7 +33,7 @@ class action_plugin_editsections2 extends DokuWiki_Action_Plugin
     /**
      * Registers event handlers
      */
-    function register(&$controller)
+    function register(Doku_Event_Handler $controller)
     {
         if (function_exists('html_secedit_get_button')) {
             $controller->register_hook(

--- a/syntax.php
+++ b/syntax.php
@@ -57,7 +57,7 @@ class syntax_plugin_editsections2 extends DokuWiki_Syntax_Plugin
     /**
      * Dummy (only for compatibility reasons)
      */
-    function handle($match, $state, $pos, &$handler)
+    function handle($match, $state, $pos, Doku_Handler $handler)
     {
         // do nothing
     }
@@ -65,7 +65,7 @@ class syntax_plugin_editsections2 extends DokuWiki_Syntax_Plugin
     /**
      * Starts section to put a secedit marker above the first heading
      */
-    function render($format, &$renderer, $data)
+    function render($format, Doku_Renderer $renderer, $data)
     {
         // no need to handle DokuWiki Lemming or earlier
         if (


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
